### PR TITLE
refresh cache sistema su evento ready di babele

### DIFF
--- a/it-IT/babele-register.js
+++ b/it-IT/babele-register.js
@@ -111,24 +111,6 @@ const domainAndSchoolsTransformation = {
   "Transmutation Spell School": "Scuola della Trasmutazione",
 };
 
-async function fixSystemCache() {
-  await cache.rebuildCache();
-  console.log("IT-TRANSLATION | Cache is ", CACHE);
-  const cacheReady = !Object.keys(CACHE)
-    .map((k) => CACHE[k])
-    .some((map) => {
-      if (map.size !== undefined) {
-        return map.size === 0;
-      }
-      return map.length === 0;
-    });
-
-  if (cacheReady) {
-    return;
-  }
-  setTimeout(fixSystemCache, 5000);
-}
-
 Hooks.once("init", () => {
   if (typeof Babele !== "undefined") {
     Babele.get().register({
@@ -170,6 +152,4 @@ Hooks.once("init", () => {
   }
 });
 
-Hooks.once("canvasReady", async () => {
-  setTimeout(fixSystemCache, 5000);
-});
+Hooks.once(`babele.ready`, cache.rebuildCache);

--- a/it-IT/module.json
+++ b/it-IT/module.json
@@ -8,7 +8,7 @@
     "dependencies": [{
       "name": "babele",
       "manifest": "https://gitlab.com/riccisi/foundryvtt-babele/raw/master/module/module.json",
-      "version": "1.28"
+      "version": "2.0.6"
     }],
     "author": "elfosardo",
     "esmodules": ["babele-register.js"],


### PR DESCRIPTION
rimosso il meccanismo temporaneo per sincronizzare la cache del sistema in favore dell'evento babele.ready aggiunto nella versione 2.0.6 di babele